### PR TITLE
add i18n-activerecord-backend

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -87,3 +87,5 @@ gem 'puma'
 gem 'dentaku'
 
 gem 'simplex'
+
+ gem 'i18n-active_record', :require => 'i18n/active_record'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -136,6 +136,8 @@ GEM
       activerecord (>= 4.2.0, < 4.3)
     httpclient (2.8.3)
     i18n (0.7.0)
+    i18n-active_record (0.2.0)
+      i18n (>= 0.5.0)
     jbuilder (2.6.1)
       activesupport (>= 3.0.0, < 5.1)
       multi_json (~> 1.2)
@@ -346,6 +348,7 @@ DEPENDENCIES
   dentaku
   devise
   dotenv-rails
+  i18n-active_record
   jbuilder (~> 2.0)
   jquery-rails
   kaminari
@@ -375,4 +378,4 @@ RUBY VERSION
    ruby 2.3.3p222
 
 BUNDLED WITH
-   1.13.7
+   1.14.6

--- a/app/assets/javascripts/translations.coffee
+++ b/app/assets/javascripts/translations.coffee
@@ -1,0 +1,3 @@
+# Place all the behaviors and hooks related to the matching controller here.
+# All this logic will automatically be available in application.js.
+# You can use CoffeeScript in this file: http://coffeescript.org/

--- a/app/assets/stylesheets/translations.scss
+++ b/app/assets/stylesheets/translations.scss
@@ -1,0 +1,3 @@
+// Place all the styles related to the Translations controller here.
+// They will automatically be included in application.css.
+// You can use Sass (SCSS) here: http://sass-lang.com/

--- a/app/controllers/translations_controller.rb
+++ b/app/controllers/translations_controller.rb
@@ -1,0 +1,74 @@
+class TranslationsController < ApplicationController
+  before_filter :find_locale
+  before_filter :retrieve_key, only: [:create, :update]
+  before_filter :find_translation, only: [:edit, :update]
+
+  def index
+    @translations = Translation.locale(@locale)
+  end
+
+  def new
+    @translation = Translation.new(locale: @locale, key: params[:key])
+  end
+
+  def create
+    @translation = Translation.new(translation_params)
+    if @translation.value == default_translation_value
+      flash[:alert] = "Your new translation is the same as the default."
+      render :new
+    else
+      if @translation.save
+        flash[:success] = "Translation for #{ @key } updated."
+        I18n.backend.reload!
+        redirect_to locale_translations_url(@locale)
+      else
+        render :new
+      end
+    end
+  end
+
+  def show
+  end
+
+  def edit
+  end
+
+  def update
+    if @translation.update(translation_params)
+      flash[:notice] = "Translation for #{ @key } updated."
+      I18n.backend.reload!
+      redirect_to locale_translations_url(@locale)
+    else
+      render :edit
+    end
+  end
+
+  def destroy
+    Translation.destroy(params[:id])
+    I18n.backend.reload!
+    redirect_to locale_translations_url(@locale)
+  end
+
+  private
+
+  def find_locale
+    @locale = params[:locale_id]
+  end
+
+  def find_translation
+    @translation = Translation.find(params[:id])
+  end
+
+  def retrieve_key
+    @key = params[:i18n_backend_active_record_translation][:key]
+  end
+
+  def translation_params
+    params.require(:i18n_backend_active_record_translation).permit(:locale,
+      :key, :value)
+  end
+
+  def default_translation_value
+    I18n.t(@translation.key, locale: @locale)
+  end
+end

--- a/app/helpers/translations_helper.rb
+++ b/app/helpers/translations_helper.rb
@@ -1,0 +1,32 @@
+module TranslationsHelper
+
+  def translation_keys(i18n_locale)
+    case i18n_locale
+    when "en"
+      en_keys
+    when "ru"
+      ru_keys
+    else
+      default_keys
+    end
+  end
+
+  def translation_for_key(translations, key)
+    hits = translations.to_a.select{ |t| t.key == key }
+    hits.first
+  end
+
+  private
+
+  def en_keys
+    [ "welcome", "site_description" ]
+  end
+
+  def ru_keys
+    [ "welcome", "site_description" ]
+  end
+
+  def default_keys
+    [ "welcome", "site_description" ]
+  end
+end

--- a/app/models/translation.rb
+++ b/app/models/translation.rb
@@ -1,0 +1,2 @@
+class Translation < ActiveRecord::Base
+end

--- a/app/views/admin/admin/index.html.erb
+++ b/app/views/admin/admin/index.html.erb
@@ -8,6 +8,9 @@
   <br/>
   <p><%= link_to "Редактор групп", student_groups_path %></p>
   <p><%= link_to "Редактор предметов", subjects_path %></p>
+  <br/>
+  <p><%= link_to "Редактор русских переводов", locale_translations_url(:ru) %></p>
+  <p><%= link_to "Редактор английских переводов", locale_translations_url(:en) %></p>
 <% end %>
 
 <p><%= link_to "Refinery CMS", refinery.admin_root_path %></p>

--- a/app/views/translations/edit.html.erb
+++ b/app/views/translations/edit.html.erb
@@ -1,0 +1,7 @@
+<%= form_for @translation, url: locale_translation_path do |form| %>
+  <%= form.label :locale %> <%= form.text_field :locale, readonly: true %>
+  <%= form.label :key %> <%= form.text_field :key, readonly: true %>
+  <%= form.label :value %> <%= form.text_area :value %>
+
+  <%= form.submit 'Save Translation' %> <%= link_to "Cancel", locale_translations_url(@locale) %>
+<% end %>

--- a/app/views/translations/index.html.erb
+++ b/app/views/translations/index.html.erb
@@ -1,0 +1,46 @@
+<h3>Перевод локали: <%= @locale %></h3>
+<table class="table">
+  <thead>
+    <tr>
+      <th>Ключ</th><th>Перевод</th><th colspan="2"></th>
+    </tr>
+  </thead>
+  <tbody>
+    <% translation_keys(@locale).each do |key| %>
+      <% translation = translation_for_key(@translations, key) %>
+      <tr id="<%= key %>">
+        <td><%= key %></td>
+        <td><%= translation.nil? ? I18n.t(key, locale: @locale) : translation.value %></td>
+        <% if translation.nil? %>
+           <td> 
+              <%= link_to  new_locale_translation_url(@locale, key: key), class: "btn btn-default", title: "Редактировать" do %>
+                <i class="glyphicon glyphicon-pencil"></i>
+              <% end %>
+           </td>
+        <% else %>
+          <td>
+            <% if can? :update, locale_translation_url(@locale, translation) %>
+              <%= link_to  edit_locale_translation_url(@locale, translation), class: "btn btn-default", title: "Редактировать" do %>
+                <i class="glyphicon glyphicon-pencil"></i>
+              <% end %>
+            <% end %>
+          </td>
+          <td> 
+            <% if can? :destroy, locale_translation_url(@locale, translation) %>
+              <%= link_to locale_translation_url(@locale, translation), class: "btn btn-default", method: :delete, title: "Удалить", data: { confirm: 'Вы уверены?' } do %>
+                <i class="glyphicon glyphicon-trash"></i>
+              <% end %>
+            <% end %>
+          </td>
+           <%end%>
+      </tr>
+    <% end %>
+  </tbody>
+</table>
+
+<br>
+
+<%= link_to new_locale_translation_path, class: "btn btn-default" do %>
+    <span class="glyphicon glyphicon-share"></span> Создать перевод
+<% end %>
+

--- a/app/views/translations/new.html.erb
+++ b/app/views/translations/new.html.erb
@@ -1,0 +1,7 @@
+<%= form_for @translation, url: locale_translations_path do |form| %>
+  <%= form.label :locale %> <%= form.text_field :locale, readonly: true %>
+  <%= form.label :key %> <%= form.text_field :key, readonly: true %>
+  <%= form.label :value %> <%= form.text_area :value, value: I18n.t(@translation.key, locale: @locale) %>
+
+  <%= form.submit 'Save Translation' %> <%= link_to "Cancel", locale_translations_url(@locale) %>
+<% end %>

--- a/config/initializers/locale.rb
+++ b/config/initializers/locale.rb
@@ -1,0 +1,14 @@
+require 'i18n/backend/active_record'
+
+Translation  = I18n::Backend::ActiveRecord::Translation
+
+if Translation.table_exists?
+  I18n.backend = I18n::Backend::ActiveRecord.new
+
+  I18n::Backend::ActiveRecord.send(:include, I18n::Backend::Memoize)
+  I18n::Backend::ActiveRecord.send(:include, I18n::Backend::Flatten)
+  I18n::Backend::Simple.send(:include, I18n::Backend::Memoize)
+  I18n::Backend::Simple.send(:include, I18n::Backend::Pluralization)
+
+  I18n.backend = I18n::Backend::Chain.new(I18n.backend, I18n::Backend::Simple.new)
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -6,7 +6,10 @@ Rails.application.routes.draw do
   #
   # We ask that you don't use the :as option here, as Refinery relies on it being the default of "refinery"
   mount Refinery::Core::Engine, at: Refinery::Core.mounted_path
-
+  
+  resources :locales do
+    resources :translations, constraints: { :id => /[^\/]+/ }
+  end
 
   resources :ws_set_model_runs
   resources :ws_param_values

--- a/db/migrate/20170416044710_create_translations.rb
+++ b/db/migrate/20170416044710_create_translations.rb
@@ -1,0 +1,13 @@
+class CreateTranslations < ActiveRecord::Migration
+  def change
+    create_table :translations do |t|
+      t.string :locale
+      t.string :key
+      t.text :value
+      t.text :interpolations
+      t.boolean :is_proc, default: false
+
+      t.timestamps null: false
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20170210150507) do
+ActiveRecord::Schema.define(version: 20170416044710) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -233,6 +233,16 @@ ActiveRecord::Schema.define(version: 20170210150507) do
     t.datetime "updated_at", null: false
   end
 
+  create_table "translations", force: :cascade do |t|
+    t.string   "locale"
+    t.string   "key"
+    t.text     "value"
+    t.text     "interpolations"
+    t.boolean  "is_proc",        default: false
+    t.datetime "created_at",                     null: false
+    t.datetime "updated_at",                     null: false
+  end
+
   create_table "users", force: :cascade do |t|
     t.string   "email",                  default: "", null: false
     t.string   "encrypted_password",     default: "", null: false
@@ -389,6 +399,8 @@ ActiveRecord::Schema.define(version: 20170210150507) do
 
   add_foreign_key "students", "student_groups"
   add_foreign_key "ws_jobs", "users"
+  add_foreign_key "ws_jobs", "users"
+  add_foreign_key "ws_jobs", "ws_methods"
   add_foreign_key "ws_jobs", "ws_methods"
   add_foreign_key "ws_model_runs", "users"
   add_foreign_key "ws_model_runs", "ws_model_statuses"

--- a/test/controllers/translations_controller_test.rb
+++ b/test/controllers/translations_controller_test.rb
@@ -1,0 +1,29 @@
+require 'test_helper'
+
+class TranslationsControllerTest < ActionController::TestCase
+  test "should get index" do
+    get :index
+    assert_response :success
+  end
+
+  test "should get new" do
+    get :new
+    assert_response :success
+  end
+
+  test "should get create" do
+    get :create
+    assert_response :success
+  end
+
+  test "should get edit" do
+    get :edit
+    assert_response :success
+  end
+
+  test "should get update" do
+    get :update
+    assert_response :success
+  end
+
+end

--- a/test/fixtures/translations.yml
+++ b/test/fixtures/translations.yml
@@ -1,0 +1,15 @@
+# Read about fixtures at http://api.rubyonrails.org/classes/ActiveRecord/FixtureSet.html
+
+one:
+  locale: MyString
+  key: MyString
+  value: MyText
+  interpolations: MyText
+  is_proc: false
+
+two:
+  locale: MyString
+  key: MyString
+  value: MyText
+  interpolations: MyText
+  is_proc: false

--- a/test/models/translation_test.rb
+++ b/test/models/translation_test.rb
@@ -1,0 +1,7 @@
+require 'test_helper'
+
+class TranslationTest < ActiveSupport::TestCase
+  # test "the truth" do
+  #   assert true
+  # end
+end


### PR DESCRIPTION
Добавление i18n-activerecord-backend, для интернационализации, не связанной с описаниями, и возможностью править локали в административных действиях.